### PR TITLE
Add backup resource and change `created_at` to a carbon instance instead of string

### DIFF
--- a/src/DataTransferObjects/BackupDto.php
+++ b/src/DataTransferObjects/BackupDto.php
@@ -22,7 +22,7 @@ final readonly class BackupDto
     }
 
     /**
-     * Create a new BackupDto from a file path
+     * Create a new BackupDto from a file path in the configured disk
      */
     public static function fromFile(string $path): self
     {

--- a/src/DataTransferObjects/BackupDto.php
+++ b/src/DataTransferObjects/BackupDto.php
@@ -14,7 +14,7 @@ final readonly class BackupDto
 {
     public function __construct(
         public string $name,
-        public string $created_at,
+        public Carbon $created_at,
         public string $size,
         public string $path,
         public string $timestamp,
@@ -31,7 +31,7 @@ final readonly class BackupDto
 
         return new self(
             name: File::name($path),
-            created_at: Carbon::createFromTimestamp($timestamp)->format('Y-m-d H:i:s'),
+            created_at: Carbon::createFromTimestamp($timestamp),
             size: StatamicStr::fileSizeForHumans($bytes, 2),
             path: $path,
             timestamp: $timestamp,
@@ -48,7 +48,7 @@ final readonly class BackupDto
 
         return new self(
             name: File::name($path),
-            created_at: Carbon::createFromTimestamp($timestamp)->format('Y-m-d H:i:s'),
+            created_at: Carbon::createFromTimestamp($timestamp),
             size: StatamicStr::fileSizeForHumans($bytes, 2),
             path: $path,
             timestamp: $timestamp,

--- a/src/Http/Controllers/Api/BackupController.php
+++ b/src/Http/Controllers/Api/BackupController.php
@@ -4,45 +4,39 @@ declare(strict_types=1);
 
 namespace Itiden\Backup\Http\Controllers\Api;
 
-use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Routing\Controller;
 use Itiden\Backup\Contracts\Repositories\BackupRepository;
+use Itiden\Backup\Http\Resources\BackupResource;
 
 class BackupController extends Controller
 {
-    public function __invoke(BackupRepository $repo): JsonResponse
+    public function __invoke(BackupRepository $repo): AnonymousResourceCollection
     {
         $backups = $repo->all();
 
-        // Required by statamic to render the table
-        // i think i want it to be in the view instead
-        $meta = [
-            'columns' => [
-                [
-                    'label' => 'Name',
-                    'field' => 'name',
-                    'visible' => true,
-                ],
-                [
-                    'label' => 'Created at',
-                    'field' => 'created_at',
-                    'visible' => true,
-                    'sortable' => true,
-                ],
-                [
-                    'label' => 'Size',
-                    'field' => 'size',
-                    'visible' => true,
-                    'sortable' => true,
+        return BackupResource::collection($backups)
+            ->additional(['meta' => [
+                // Required by statamic to render the table
+                'columns' => [
+                    [
+                        'label' => 'Name',
+                        'field' => 'name',
+                        'visible' => true,
+                    ],
+                    [
+                        'label' => 'Created at',
+                        'field' => 'created_at',
+                        'visible' => true,
+                        'sortable' => true,
+                    ],
+                    [
+                        'label' => 'Size',
+                        'field' => 'size',
+                        'visible' => true,
+                        'sortable' => true,
+                    ]
                 ]
-            ]
-        ];
-
-        $data = [
-            'data' => $backups,
-            'meta' => $meta,
-        ];
-
-        return response()->json($data);
+            ]]);
     }
 }

--- a/src/Http/Resources/BackupResource.php
+++ b/src/Http/Resources/BackupResource.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Itiden\Backup\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \Itiden\Backup\DataTransferObjects\BackupDto
+ */
+class BackupResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'name' => $this->name,
+            'created_at' => $this->created_at->format('Y-m-d H:i:s'),
+            'path' => $this->path,
+            'timestamp' => $this->timestamp,
+            'size' => $this->size,
+        ];
+    }
+}


### PR DESCRIPTION
Changes created at to carbon instead of string, so it is easier to format the date wherever.

Also add a backup json resource.