### PR TITLE
Fix backupdto not parsing timestamp correctly when name has "-"

### DIFF
--- a/src/DataTransferObjects/BackupDto.php
+++ b/src/DataTransferObjects/BackupDto.php
@@ -7,7 +7,6 @@ namespace Itiden\Backup\DataTransferObjects;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 use Statamic\Support\Str as StatamicStr;
 
 final readonly class BackupDto
@@ -26,7 +25,7 @@ final readonly class BackupDto
      */
     public static function fromFile(string $path): self
     {
-        $timestamp = Str::between(basename($path), '-', '.zip');
+        $timestamp = str(basename($path))->afterLast('-')->before('.zip')->toString();
         $bytes = Storage::disk(config('backup.destination.disk'))->size($path);
 
         return new self(
@@ -43,7 +42,7 @@ final readonly class BackupDto
      */
     public static function fromAbsolutePath(string $path): self
     {
-        $timestamp = Str::between(basename($path), '-', '.zip');
+        $timestamp = str(basename($path))->afterLast('-')->before('.zip')->toString();
         $bytes = File::size($path);
 
         return new self(

--- a/tests/Unit/BackupDtoTest.php
+++ b/tests/Unit/BackupDtoTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Carbon\Carbon;
+use Itiden\Backup\Contracts\Repositories\BackupRepository;
+use Itiden\Backup\DataTransferObjects\BackupDto;
+use Itiden\Backup\Facades\Backuper;
+
+uses()->group('backupdto');
+
+it('will resolve valid timestamp when app name has many dashes', function () {
+    config(['app.name' => 'app-with-many-dashes']);
+
+    $fakeTime = Carbon::parse('2021-01-01 12:00:00');
+
+    Carbon::setTestNow($fakeTime);
+
+    $backup = Backuper::backup();
+
+    expect($backup->timestamp)->toBeString();
+    expect($backup->timestamp)->toBe((string) $fakeTime->timestamp);
+});

--- a/tests/Unit/BackupDtoTest.php
+++ b/tests/Unit/BackupDtoTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Carbon\Carbon;
-use Itiden\Backup\Contracts\Repositories\BackupRepository;
-use Itiden\Backup\DataTransferObjects\BackupDto;
 use Itiden\Backup\Facades\Backuper;
 
 uses()->group('backupdto');


### PR DESCRIPTION
Fix bug that would parse timestamps containing `-` wrong.

ex: `app-name` would result in "timestamp" `name-xxxxxxxxxxxx` which is clearly wrong. 