### PR TITLE
Feature/improve commands

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,7 @@
     </source>
     <php>
         <env name="DB_CONNECTION" value="testing"/>
+        <env name="APP_ENV" value="testing"/>
         <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
   </php>
 </phpunit>

--- a/src/Console/Commands/BackupCommand.php
+++ b/src/Console/Commands/BackupCommand.php
@@ -7,6 +7,8 @@ namespace Itiden\Backup\Console\Commands;
 use Illuminate\Console\Command;
 use Itiden\Backup\Facades\Backuper;
 
+use function Laravel\Prompts\spin;
+
 /**
  * Backup site
  */
@@ -18,10 +20,8 @@ class BackupCommand extends Command
 
     public function handle()
     {
-        $this->components->info('Backing up content');
+        $backup = spin(fn () => Backuper::backup(), 'Backing up...');
 
-        $backup_location = Backuper::backup();
-
-        $this->components->info('Backup saved to ' . $backup_location->path);
+        $this->components->info('Backup saved to ' . $backup->path);
     }
 }

--- a/src/Console/Commands/BackupCommand.php
+++ b/src/Console/Commands/BackupCommand.php
@@ -7,6 +7,7 @@ namespace Itiden\Backup\Console\Commands;
 use Illuminate\Console\Command;
 use Itiden\Backup\Facades\Backuper;
 
+use function Laravel\Prompts\info;
 use function Laravel\Prompts\spin;
 
 /**
@@ -22,6 +23,6 @@ class BackupCommand extends Command
     {
         $backup = spin(fn () => Backuper::backup(), 'Backing up...');
 
-        $this->components->info('Backup saved to ' . $backup->path);
+        info('Backup saved to ' . $backup->path);
     }
 }

--- a/src/Console/Commands/BackupCommand.php
+++ b/src/Console/Commands/BackupCommand.php
@@ -7,8 +7,7 @@ namespace Itiden\Backup\Console\Commands;
 use Illuminate\Console\Command;
 use Itiden\Backup\Facades\Backuper;
 
-use function Laravel\Prompts\info;
-use function Laravel\Prompts\spin;
+use function Laravel\Prompts\{info, spin};
 
 /**
  * Backup site

--- a/src/Console/Commands/ClearFilesCommand.php
+++ b/src/Console/Commands/ClearFilesCommand.php
@@ -7,6 +7,8 @@ namespace Itiden\Backup\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
+use function Laravel\Prompts\info;
+
 /**
  * Clear the backup temp directory
  */
@@ -18,14 +20,14 @@ class ClearFilesCommand extends Command
 
     public function handle()
     {
-        if (! File::exists(config('backup.temp_path'))) {
-            $this->components->info('Backup temp directory does not exist, no need to clear it.');
+        if (!File::exists(config('backup.temp_path'))) {
+            info('Backup temp directory does not exist, no need to clear it.');
 
             return;
         }
 
         File::cleanDirectory(config('backup.temp_path'));
 
-        $this->components->info('Backup temp directory cleared successfully');
+        info('Backup temp directory cleared successfully');
     }
 }

--- a/src/Console/Commands/RestoreCommand.php
+++ b/src/Console/Commands/RestoreCommand.php
@@ -6,15 +6,20 @@ namespace Itiden\Backup\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Itiden\Backup\Contracts\Repositories\BackupRepository;
 use Itiden\Backup\DataTransferObjects\BackupDto;
 use Itiden\Backup\Facades\Restorer;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\spin;
 
 /**
  * Restore content from a directory / backup
  */
 class RestoreCommand extends Command implements PromptsForMissingInput
 {
-    protected $signature = 'statamic:backup:restore {path} {--force}';
+    protected $signature = 'statamic:backup:restore {--path} {--force}';
 
     protected $description = 'Reset or restore content from a directory / backup';
 
@@ -25,10 +30,27 @@ class RestoreCommand extends Command implements PromptsForMissingInput
         ];
     }
 
-    public function handle()
+    public function handle(BackupRepository $repo)
     {
-        if ($this->option('force') || $this->confirm('Are you sure you want to restore your content?')) {
-            Restorer::restore(BackupDto::fromAbsolutePath($this->argument('path')));
+        /* @var BackupDto $backup */
+        $backup = match (true) {
+            $this->hasOption('path') => BackupDto::fromAbsolutePath($this->option('path')),
+            default => BackupDto::fromFile(select(
+                'Which backup do you want to restore to?',
+                $repo->all()->flatMap(
+                    fn (BackupDto $backup) => [$backup->path => $backup->path]
+                )
+            )),
+        };
+
+        if (
+            $this->option('force')
+            || confirm(
+                label: "Are you sure you want to restore your content?",
+                hint: "This will overwrite your current content with state from {$backup->created_at->format('Y-m-d H:i:s')}"
+            )
+        ) {
+            spin(fn () => Restorer::restore($backup), 'Restoring backup');
         }
     }
 }

--- a/src/Console/Commands/RestoreCommand.php
+++ b/src/Console/Commands/RestoreCommand.php
@@ -10,9 +10,7 @@ use Itiden\Backup\Contracts\Repositories\BackupRepository;
 use Itiden\Backup\DataTransferObjects\BackupDto;
 use Itiden\Backup\Facades\Restorer;
 
-use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\select;
-use function Laravel\Prompts\spin;
+use function Laravel\Prompts\{confirm, spin, info, select};
 
 /**
  * Restore content from a directory / backup

--- a/src/Console/Commands/RestoreCommand.php
+++ b/src/Console/Commands/RestoreCommand.php
@@ -45,6 +45,8 @@ class RestoreCommand extends Command implements PromptsForMissingInput
             )
         ) {
             spin(fn () => Restorer::restore($backup), 'Restoring backup');
+
+            info('Backup restored!');
         }
     }
 }

--- a/src/Console/Commands/RestoreCommand.php
+++ b/src/Console/Commands/RestoreCommand.php
@@ -19,25 +19,19 @@ use function Laravel\Prompts\spin;
  */
 class RestoreCommand extends Command implements PromptsForMissingInput
 {
-    protected $signature = 'statamic:backup:restore {--path} {--force}';
+    protected $signature = 'statamic:backup:restore {--path=} {--force}';
 
     protected $description = 'Reset or restore content from a directory / backup';
-
-    protected function promptForMissingArgumentsUsing()
-    {
-        return [
-            'path' => 'Which filepath does your backup have?',
-        ];
-    }
 
     public function handle(BackupRepository $repo)
     {
         /* @var BackupDto $backup */
         $backup = match (true) {
-            $this->hasOption('path') => BackupDto::fromAbsolutePath($this->option('path')),
+            (bool) $this->option('path') => BackupDto::fromAbsolutePath($this->option('path')),
             default => BackupDto::fromFile(select(
-                'Which backup do you want to restore to?',
-                $repo->all()->flatMap(
+                label: 'Which backup do you want to restore to?',
+                scroll: 10,
+                options: $repo->all()->flatMap(
                     fn (BackupDto $backup) => [$backup->path => $backup->path]
                 )
             )),

--- a/tests/Feature/RestoreBackupTest.php
+++ b/tests/Feature/RestoreBackupTest.php
@@ -75,19 +75,19 @@ it('will not restore from command if you say no', function () {
 
     File::cleanDirectory(config('backup.content_path'));
 
-    $this->artisan('statamic:backup:restore', ['path' => Storage::path($backup->path)])
+    $this->artisan('statamic:backup:restore', ['--path' => Storage::path($backup->path)])
         ->expectsConfirmation('Are you sure you want to restore your content?', 'no');
 
     expect(File::isEmptyDirectory(config('backup.content_path')))->toBeTrue();
 
-    $this->artisan('statamic:backup:restore', ['path' => Storage::path($backup->path), '--force' => true])
+    $this->artisan('statamic:backup:restore', ['--path' => Storage::path($backup->path), '--force' => true])
         ->assertExitCode(0);
 });
 
 it('can restore from path command', function () {
     $backup = Backuper::backup();
 
-    $this->artisan('statamic:backup:restore', ['path' => Storage::path($backup->path), '--force' => true])
+    $this->artisan('statamic:backup:restore', ['--path' => Storage::path($backup->path), '--force' => true])
         ->assertExitCode(0);
 
     expect(File::isEmptyDirectory(config('backup.content_path')))->toBeFalse();


### PR DESCRIPTION
This PR changes the console ui by using `laravel/prompts` (since it's used by statamic - it (in theory) should be a more seamless experience).

Also changed the restore command signature to be a bit more easy to use.

```php
// prev
php artisan statamic:backup:restore "/my/path"

// new
// will display a select with the same backups as in cp
php artisan statamic:backup:restore

// with optional flag for path and force
php artisan statamic:backup:restore --path="/my/path"
```

Hopefully this makes it more pleasant to use the console commands.

## TODO
- [ ] Clear command should probably be renamed
- [ ] Descriptions for the commands should be improved
- [ ] Figure out if we should keep the statamic "namespace"?