### PR TITLE
fix: download destination disk

### DIFF
--- a/src/Http/Controllers/DownloadBackupController.php
+++ b/src/Http/Controllers/DownloadBackupController.php
@@ -25,6 +25,6 @@ class DownloadBackupController extends Controller
 
         $backup->getMetadata()->addDownload(auth()->user());
 
-        return Storage::disk(config('backup.backup.disk'))->download($backup->path);
+        return Storage::disk(config('backup.destination.disk'))->download($backup->path);
     }
 }


### PR DESCRIPTION
The backup.backup.disk variable is not set in the config file. The correct path is backup.destination.disk.