### PR TITLE
feat: make upload chunksize configurable

### DIFF
--- a/client/src/components/Backup.vue
+++ b/client/src/components/Backup.vue
@@ -19,18 +19,22 @@ export default {
     "backup-listing": Listing,
     "backup-actions": Actions,
   },
+  props: {
+    chunkSize: {
+      type: Number,
+      default: 1 * 1024 * 1024, // 1MB
+    },
+  },
   created() {
+    console.log(this.chunkSize)
+    window.backup = {
+      chunkSize: this.chunkSize
+    };
+
     if (!this.$store.hasModule('backup-provider')) {
       this.$store.registerModule('backup-provider', store);
       this.$store.dispatch('backup-provider/pollEndpoint');
     }
-  },
-  data() {
-    return {
-      serverState: "initializing",
-      uploads: [],
-      url: cp_url("/backups"),
-    };
   },
   destroy() {
     this.$store.dispatch('backup-provider/stopPolling');

--- a/client/src/components/Backup.vue
+++ b/client/src/components/Backup.vue
@@ -22,7 +22,7 @@ export default {
   props: {
     chunkSize: {
       type: Number,
-      default: 1 * 1024 * 1024, // 1MB
+      default: 2 * 1024 * 1024, // 2MB
     },
   },
   created() {

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -51,7 +51,7 @@ export default {
         "X-CSRF-TOKEN":
           document.querySelector("input[name=_token]").value,
       },
-      chunkSize: window.backup.chunkSize || 1 * 1024 * 1024, // 1MB
+      chunkSize: window.backup.chunkSize || 2 * 1024 * 1024, // 2MB
       forceChunkSize: true,
       maxChunkRetries: 1,
       maxFiles: 1,

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -51,6 +51,8 @@ export default {
         "X-CSRF-TOKEN":
           document.querySelector("input[name=_token]").value,
       },
+      chunkSize: window.backup.chunkSize || 1 * 1024 * 1024, // 1MB
+      forceChunkSize: true,
       maxChunkRetries: 1,
       maxFiles: 1,
       testChunks: false,

--- a/config/backup.php
+++ b/config/backup.php
@@ -11,6 +11,11 @@ return [
     ],
 
     /**
+     * The upload chunk size
+     */
+    'chunk_size' => 2 * 1024 * 1024,
+
+    /**
      * The directory where backup will put metadata files
      */
     'metadata_path' => storage_path('statamic-backups'),

--- a/resources/views/backups.blade.php
+++ b/resources/views/backups.blade.php
@@ -5,6 +5,6 @@
 
 @csrf
 
-<itiden-backup />
+<itiden-backup :chunk-size="{{ config('backup.chunk_size') }}" />
 
 @endsection


### PR DESCRIPTION
This PR adds a config option for `chunk_size`, which controls the uploads.

The default is set to 2mb, which is the default php `upload_max_filesize`.