### PR TITLE
fix(chunky): improve file uploads

### DIFF
--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -51,11 +51,12 @@ export default {
         "X-CSRF-TOKEN":
           document.querySelector("input[name=_token]").value,
       },
+      fileType: ["zip"],
+      testChunks: true,
       chunkSize: window.backup.chunkSize || 2 * 1024 * 1024, // 2MB
       forceChunkSize: true,
       maxChunkRetries: 1,
       maxFiles: 1,
-      testChunks: false,
     });
 
     // Resumable.js isn't supported, fall back on a different method

--- a/src/DataTransferObjects/ChunkyTestDto.php
+++ b/src/DataTransferObjects/ChunkyTestDto.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 final readonly class ChunkyTestDto
 {
     public function __construct(
-        public string $path,
+        public string $identifier,
         public string $filename,
         public int $currentChunk,
     ) {
@@ -21,7 +21,7 @@ final readonly class ChunkyTestDto
     public static function fromRequest(Request $request): static
     {
         return new static(
-            path: 'temp/' . $request->input('resumableIdentifier'),
+            identifier: $request->input('resumableIdentifier'),
             filename: $request->input('resumableFilename'),
             currentChunk: (int) $request->input('resumableChunkNumber'),
         );

--- a/src/DataTransferObjects/ChunkyUploadDto.php
+++ b/src/DataTransferObjects/ChunkyUploadDto.php
@@ -11,7 +11,6 @@ final readonly class ChunkyUploadDto
 {
     // @mago-ignore maintainability/excessive-parameter-list
     public function __construct(
-        public string $path,
         public string $filename,
         public int $totalChunks,
         public int $currentChunk,
@@ -27,7 +26,6 @@ final readonly class ChunkyUploadDto
     public static function fromRequest(Request $request): static
     {
         return new static(
-            path: 'temp/' . $request->input('resumableIdentifier'),
             filename: $request->input('resumableFilename'),
             totalChunks: (int) $request->input('resumableTotalChunks'),
             currentChunk: (int) $request->input('resumableChunkNumber'),

--- a/src/Http/Controllers/UploadController.php
+++ b/src/Http/Controllers/UploadController.php
@@ -21,7 +21,10 @@ final readonly class UploadController
             $repo,
             $backuper,
         ): void {
-            $repo->add($completeFile);
+            $backup = $repo->add($completeFile);
+
+            $backuper->addMetaFromZipToBackupMeta($completeFile, $backup);
+
             $backuper->enforceMaxBackups();
         });
     }

--- a/tests/Feature/CreateBackupTest.php
+++ b/tests/Feature/CreateBackupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Event;
 use Itiden\Backup\Contracts\Repositories\BackupRepository;
+use Itiden\Backup\DataTransferObjects\BackupDto;
 use Itiden\Backup\Events\BackupCreated;
 use Itiden\Backup\Events\BackupFailed;
 use Itiden\Backup\Exceptions\RestoreFailed;
@@ -139,11 +140,19 @@ describe('api:create', function (): void {
 
         postJson(cp_route('api.itiden.backup.store'));
 
-        expect(app(BackupRepository::class)
+        /** @var BackupDto */
+        $backup = app(BackupRepository::class)
             ->all()
-            ->first()
-            ->getMetadata()
-            ->getSkippedPipes())->toHaveCount(1);
+            ->first();
+
+        $metadata = $backup->getMetadata();
+
+        expect($metadata->getSkippedPipes())->toHaveCount(1);
+        expect(
+            $metadata
+                ->getSkippedPipes()
+                ->first()->pipe,
+        )->toBe(SkippingPipe::class);
     });
 
     it('can encrypt backup with password', function (): void {

--- a/tests/Unit/BackuperTest.php
+++ b/tests/Unit/BackuperTest.php
@@ -35,6 +35,14 @@ describe('backuper', function (): void {
             Storage::disk(config('backup.destination.disk'))->path($backup->path),
             PATHINFO_EXTENSION,
         ))->toBe('zip');
+
+        $zipper = Zipper::read(Storage::disk(config('backup.destination.disk'))->path($backup->path));
+
+        $meta = $zipper->getMeta();
+        expect($meta)->toHaveKey('is_backup', 'true');
+        expect($meta)->toHaveKey('version', '1');
+
+        $zipper->close();
     });
 
     it('backups correct files', function (): void {


### PR DESCRIPTION
This PR fixes so that the identifiers are used to store files, and improves performance a bit by skipping a file move.

Also activated the "test" functionality in resumable so that the uploads can be resumed after reloads and whatnot 