### PR TITLE
fix: user getting logged out when doing backups or restores

### DIFF
--- a/src/Backuper.php
+++ b/src/Backuper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Itiden\Backup;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Pipeline;
 use Itiden\Backup\Contracts\Repositories\BackupRepository;
@@ -29,7 +30,7 @@ final class Backuper
      *
      * @throws Exceptions\BackupFailed
      */
-    public function backup(): BackupDto
+    public function backup(?Authenticatable $user = null): BackupDto
     {
         $lock = $this->stateManager->getLock();
 
@@ -60,8 +61,6 @@ final class Backuper
             $backup = $this->repository->add($temp_zip_path);
 
             $metadata = static::addMetaFromZipToBackupMeta($temp_zip_path, $backup);
-
-            $user = auth()->user();
 
             if ($user) {
                 $metadata->setCreatedBy($user);

--- a/src/Jobs/BackupJob.php
+++ b/src/Jobs/BackupJob.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Itiden\Backup\Jobs;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Itiden\Backup\Backuper;
 use Itiden\Backup\StateManager;
-use Statamic\Contracts\Auth\User;
 
 final class BackupJob implements ShouldQueue
 {
@@ -19,7 +19,7 @@ final class BackupJob implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        private User $user,
+        private Authenticatable $user,
     ) {}
 
     /**
@@ -27,9 +27,7 @@ final class BackupJob implements ShouldQueue
      */
     public function handle(Backuper $backuper, Repository $cache): void
     {
-        auth()->login($this->user); // ugly but it works;
-
-        $backuper->backup();
+        $backuper->backup(user: $this->user);
 
         $cache->forget(StateManager::JOB_QUEUED_KEY);
     }

--- a/src/Jobs/RestoreJob.php
+++ b/src/Jobs/RestoreJob.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Itiden\Backup\Jobs;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Itiden\Backup\Restorer;
 use Itiden\Backup\StateManager;
-use Statamic\Contracts\Auth\User;
 
 final class RestoreJob implements ShouldQueue
 {
@@ -20,7 +20,7 @@ final class RestoreJob implements ShouldQueue
      */
     public function __construct(
         private string $id,
-        private User $user,
+        private Authenticatable $user,
     ) {}
 
     /**
@@ -28,9 +28,10 @@ final class RestoreJob implements ShouldQueue
      */
     public function handle(Restorer $backuper, Repository $cache): void
     {
-        auth()->login($this->user); // ugly but it works;
-
-        $backuper->restoreFromId($this->id);
+        $backuper->restoreFromId(
+            id: $this->id,
+            user: $this->user,
+        );
 
         $cache->forget(StateManager::JOB_QUEUED_KEY);
     }

--- a/src/Restorer.php
+++ b/src/Restorer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Itiden\Backup;
 
 use Exception;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Pipeline;
@@ -30,7 +31,7 @@ final class Restorer
      *
      * @throws Exception
      */
-    public function restoreFromId(string $id): void
+    public function restoreFromId(string $id, ?Authenticatable $user = null): void
     {
         $backup = $this->repository->find($id);
 
@@ -38,7 +39,7 @@ final class Restorer
             throw new RuntimeException("Backup with id {$id} not found.");
         }
 
-        $this->restore($backup);
+        $this->restore($backup, $user);
     }
 
     /**
@@ -46,7 +47,7 @@ final class Restorer
      *
      * @throws RestoreFailed
      */
-    public function restore(BackupDto $backup): void
+    public function restore(BackupDto $backup, ?Authenticatable $user = null): void
     {
         $lock = $this->stateManager->getLock();
 
@@ -70,7 +71,6 @@ final class Restorer
 
             event(new BackupRestored($backup));
 
-            $user = auth()->user();
             if ($user) {
                 $backup->getMetadata()->addRestore($user);
             }


### PR DESCRIPTION
I am pretty sure what caused this was that the job ran `auth()->login` and thus invalidated the actual session.